### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,7 @@
 
 name: Java CI with Maven
 permissions:
-  actions: write
+  actions: read
   contents: write
   checks: write
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,9 +10,9 @@
 
 name: Java CI with Maven
 permissions:
-  actions: read
-  contents: read
-  checks: read
+  actions: write
+  contents: write
+  checks: write
 
 on:
   workflow_dispatch:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -9,6 +9,8 @@
 # documentation.
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,6 @@
 
 name: Java CI with Maven
 permissions:
-  actions: read
   contents: read
   checks: write
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -10,7 +10,9 @@
 
 name: Java CI with Maven
 permissions:
+  actions: read
   contents: read
+  checks: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -11,7 +11,7 @@
 name: Java CI with Maven
 permissions:
   actions: read
-  contents: write
+  contents: read
   checks: write
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/VeriVote/beast/security/code-scanning/1](https://github.com/VeriVote/beast/security/code-scanning/1)

To fix the problem, explicitly set the `permissions` block to limit the `GITHUB_TOKEN`'s access. The best way is to add `permissions: contents: read` at the top level of the workflow (just after the `name:` field and before `on:`), which will apply to all jobs unless overridden. This ensures the workflow only has read access to repository contents, adhering to the principle of least privilege. No other changes are needed, as none of the workflow steps require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
